### PR TITLE
Support for self-closing tags

### DIFF
--- a/src/xml.c
+++ b/src/xml.c
@@ -536,7 +536,7 @@ static struct xml_node* xml_parse_node(struct xml_parser* parser) {
 	}
 
 	/* If tag ends with `/' it's self closing, skip content lookup */
-	if ('/' == tag_open->buffer[tag_open->length - 1]) {
+	if (tag_open->length > 0 && '/' == tag_open->buffer[tag_open->length - 1]) {
 		/* Drop `/'
 		 */
 		--tag_open->length;


### PR DESCRIPTION
Hi,

I'm using xml.c for my project and I've noticed that support for self-closing tags (eg. <page/> which is well-formed XML documnet by the way) is missing. Attempt to parse an XML with self-closed tag triggers errors and SEGV.

I wrote this small check to prevent such situations. Unfortunately it uses goto but alternative if-else makes following laaaaaarge block of code ident far to right which looks awful. Currently I don't know any better solutions for now but I'm opened to suggestions.

If you like the idea, tell me and we will work something out to push it upstream.

PS. Bravo for very readable, well-documented code, I was able to find error cause in couple of minutes :)
