### PR TITLE
Fix for xml_easy_content() for nodes with no content

### DIFF
--- a/src/xml.c
+++ b/src/xml.c
@@ -143,8 +143,9 @@ static _Bool xml_string_equals(struct xml_string* a, struct xml_string* b) {
  * [PRIVATE]
  */
 static uint8_t* xml_string_clone(struct xml_string* s) {
-	if (!s)
+	if (!s) {
 		return 0;
+	}
 
 	uint8_t* clone = calloc(s->length + 1, sizeof(uint8_t));
 


### PR DESCRIPTION
Hi,

When there's no content in node, xml_easy_content() causes SEGV. I think it should be more friendly and return NULL :).

If you like it, tell me and we will work something out to push it upstream.
