### PR TITLE
Whitespaces after opening tag must be consumed

### DIFF
--- a/src/xml.c
+++ b/src/xml.c
@@ -359,6 +359,7 @@ static struct xml_string* xml_parse_tag_end(struct xml_parser* parser) {
 			length++;
 		}
 	}
+	xml_skip_whitespace(parser);
 
 	/* Consume `>'
 	 */


### PR DESCRIPTION
Whitespaces after an opening tag must be consumed otherwise valid XML will not be parsed.