### PR TITLE
fix: include /usr/include/malloc/ if platform is macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,9 @@ ADD_LIBRARY(xml STATIC
 
 # Build unit cases
 INCLUDE_DIRECTORIES(${SOURCE_DIRECTORY})
+IF (APPLE)
+    INCLUDE_DIRECTORIES("/usr/include/malloc/")
+ENDIF()
 
 ADD_EXECUTABLE(test-xml-c
 	${TEST_SOURCE_DIRECTORY}/test-xml-c


### PR DESCRIPTION
- if platform is macOS, malloc (`/usr/include/malloc/`) needs to be included