### PR TITLE
Fix compilation error on macOS using Clang.

### DIFF
--- a/src/xml.c
+++ b/src/xml.c
@@ -25,7 +25,11 @@
 #endif
 
 #include <ctype.h>
+
+#ifndef __MACH__
 #include <malloc.h>
+#endif
+
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdio.h>


### PR DESCRIPTION
When building the current master branch on macOS via Clang, this error is given:
```
xml.c/src/xml.c:29:10: fatal error: 'malloc.h' file not found
```
There is a branch called `patch/fix-macosx-build` that removes `malloc.h`, but this is an old version of xml.c that does not support attributes, and I need attributes for a project.

This new code uses the preprocessor to determine what platform the code is being compiled on. Only if the platform is not Mach based (and good luck finding a modern Mach OS other than macOS) is `malloc.h` is `malloc.h` included. This is to fix any issues that might arise on other systems. I know that on macOS 11.2, this code compiles and works for my project.