### PR TITLE
Fixed missing `stdio.h` include

### DIFF
--- a/src/xml.c
+++ b/src/xml.c
@@ -20,6 +20,8 @@
  *
  *  3. This notice may not be removed or altered from any source distribution.
  */
+#include "xml.h"
+
 #ifdef XML_PARSER_VERBOSE
 #include <alloca.h>
 #endif
@@ -34,7 +36,6 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include "xml.h"
 
 
 

--- a/src/xml.h
+++ b/src/xml.h
@@ -27,9 +27,10 @@
 /**
  * Includes
  */
-#include <stdint.h>
-#include <string.h>
 #include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
`xml.h` required `stdio.h` to be included first, which is unfortunate. Switch `xml.c` include order to include `xml.h` first in order to catch such mistakes in the future.